### PR TITLE
Enhancement - Twig Extension to render Breadcrumb Title as Page Title

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ Please follow the steps given [here](https://github.com/Abhoryo/APYBreadcrumbTra
  - [PHP configuration](Resources/doc/php_configuration.md)
  - [Twig configuration](Resources/doc/twig_configuration.md)
  - [Render the breadcrumb trail](Resources/doc/rendering.md)
+ - [Render the breadcrumb title](Resources/doc/rendering_breadcrumb_title.md)
  - [Override the template](Resources/doc/override_template.md)

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,6 +6,7 @@
     <parameters>
         <parameter key="apy_breadcrumb_trail.class">APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail</parameter>
         <parameter key="apy_breadcrumb_trail.twig.extension.class">APY\BreadcrumbTrailBundle\Twig\BreadcrumbTrailExtension</parameter>
+        <parameter key="apy_breadcrumb_trail.twig.title_extension.class">APY\BreadcrumbTrailBundle\Twig\TitleExtension</parameter>
         <parameter key="apy_breadcrumb_trail.annotation.listener.class">APY\BreadcrumbTrailBundle\EventListener\BreadcrumbListener</parameter>
     </parameters>
 
@@ -20,6 +21,11 @@
 
         <service id="apy_breadcrumb_trail.twig.extension" class="%apy_breadcrumb_trail.twig.extension.class%">
             <argument type="service" id="service_container" />
+            <tag name="twig.extension" />
+        </service>
+
+        <service id="apy_breadcrumb_trail.twig.title_extension" class="%apy_breadcrumb_trail.twig.title_extension.class%">
+            <argument type="service" id="apy_breadcrumb_trail" />
             <tag name="twig.extension" />
         </service>
 

--- a/Resources/doc/rendering_breadcrumb_title.md
+++ b/Resources/doc/rendering_breadcrumb_title.md
@@ -1,0 +1,7 @@
+# Render a breadcrumb title in a template
+
+```twig
+{{ pageTitle is defined ? pageTitle }}
+```
+
+This will automatically render the last breadcrumb in the array and display it.

--- a/Tests/Twig/TitleExtensionTest.php
+++ b/Tests/Twig/TitleExtensionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace APY\BreadcrumbTrailBundle\Tests\Twig;
+
+
+use APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail;
+use APY\BreadcrumbTrailBundle\Twig\TitleExtension;
+
+/**
+ * Class TitleExtensionTest
+ */
+class TitleExtensionTest extends \PHPUnit_Framework_TestCase
+{
+
+    /** @var TitleExtension $_title */
+    private $_title;
+
+    public function setUp()
+    {
+        $url = $this->getMockBuilder('Symfony\Component\Routing\Generator\UrlGeneratorInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $trail = new Trail($url, $container);
+        $trail->add('Test', NULL, array());
+        $this->_title = new TitleExtension($trail);
+    }
+
+    public function testGetGlobals()
+    {
+        $actual = $this->_title->getGlobals();
+
+        $expected = array(
+            'pageTitle' =>  $this->_title->returnCurrentBreadcrumb()
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testReturnPath()
+    {
+        $this->assertEquals('Test', $this->_title->returnCurrentBreadcrumb());
+    }
+
+    public function testGetName()
+    {
+        $this->assertEquals('pageTitleRender', $this->_title->getName());
+    }
+
+}

--- a/Twig/BreadcrumbTrailExtension.php
+++ b/Twig/BreadcrumbTrailExtension.php
@@ -12,6 +12,7 @@
 namespace APY\BreadcrumbTrailBundle\Twig;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Twig_SimpleFunction;
 
 /**
  * Provides an extension for Twig to output breadcrumbs
@@ -42,7 +43,11 @@ class BreadcrumbTrailExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            "apy_breadcrumb_trail_render" => new \Twig_Function_Method($this, "renderBreadcrumbTrail", array("is_safe" => array("html"))),
+            new Twig_SimpleFunction(
+                'apy_breadcrumb_trail_render',
+                array($this, "renderBreadcrumbTrail"),
+                array("is_safe" => array("html"))
+            )
         );
     }
 

--- a/Twig/TitleExtension.php
+++ b/Twig/TitleExtension.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace APY\BreadcrumbTrailBundle\Twig;
+
+
+use APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail;
+
+/**
+ * Class TitleExtension
+ */
+class TitleExtension extends \Twig_Extension
+{
+    /** @var Trail $_trail */
+    private $_trail;
+
+    public function __construct(Trail $trail)
+    {
+        $this->_trail = $trail;
+    }
+
+    public function getGlobals()
+    {
+        return array(
+            'pageTitle' => $this->returnCurrentBreadcrumb()
+        );
+    }
+
+    public function returnCurrentBreadcrumb()
+    {
+        $title = '';
+
+        foreach($this->_trail as $breadcrumb) {
+            $title = $breadcrumb->title;
+        }
+
+        return $title;
+    }
+
+    public function getName()
+    {
+        return 'pageTitleRender';
+    }
+}


### PR DESCRIPTION
First off, thanks for this great extension! It has worked out really well. I just wish it had more tests, but that can be dealt with later.

Here is a PR of a simple twig extension to possibly add to the bundle. It really isn't related to breadcrumbs, but it has saved me time with past projects. As you can see the PR includes the extension, tests, and documentation. If you need anything else feel free to ask. Thanks again for creating this!

Cheers!