### PR TITLE
Removed depreciated call to Twig_Function_Method with SF 2.7 and changed it to Twig_SimpleFunction

### DIFF
--- a/Twig/BreadcrumbTrailExtension.php
+++ b/Twig/BreadcrumbTrailExtension.php
@@ -12,6 +12,7 @@
 namespace APY\BreadcrumbTrailBundle\Twig;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Twig_SimpleFunction;
 
 /**
  * Provides an extension for Twig to output breadcrumbs
@@ -42,7 +43,11 @@ class BreadcrumbTrailExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            "apy_breadcrumb_trail_render" => new \Twig_Function_Method($this, "renderBreadcrumbTrail", array("is_safe" => array("html"))),
+            new Twig_SimpleFunction(
+                'apy_breadcrumb_trail_render',
+                array($this, "renderBreadcrumbTrail"),
+                array("is_safe" => array("html"))
+            )
         );
     }
 


### PR DESCRIPTION
Simple PR to separate my original one and remove depreciated methods.