### PR TITLE
Fix Twig deprecations

### DIFF
--- a/Twig/BreadcrumbTrailExtension.php
+++ b/Twig/BreadcrumbTrailExtension.php
@@ -42,7 +42,7 @@ class BreadcrumbTrailExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            "apy_breadcrumb_trail_render" => new \Twig_Function_Method($this, "renderBreadcrumbTrail", array("is_safe" => array("html"))),
+            new \Twig_SimpleFunction("apy_breadcrumb_trail_render", array($this, "renderBreadcrumbTrail"), array("is_safe" => array("html"))),
         );
     }
 


### PR DESCRIPTION
Use `Twig_SimpleFunction` instead of deprecated `Twig_Function_Method`.