### PR TITLE
Added complex route parameters functionnality

### DIFF
--- a/BreadcrumbTrail/Trail.php
+++ b/BreadcrumbTrail/Trail.php
@@ -93,8 +93,8 @@ class Trail implements \IteratorAggregate, \Countable
 
                 foreach ($matches as $match) {
                     $varName    = $match['variable'][0];
-                    $functions  = explode('.', $match['function'][0]);
-                    $parameters = explode(',', $match['parameters'][0]);
+                    $functions  = $match['function'][0] ? explode('.', $match['function'][0]) : array();
+                    $parameters = $match['parameters'][0] ? explode(',', $match['parameters'][0]) : array();
                     $nbCalls    = count($functions);
 
                     if($request->attributes->has($varName)) {
@@ -146,8 +146,8 @@ class Trail implements \IteratorAggregate, \Countable
                             foreach ($matches AS $match) {
 
                                 $varName    = $match['variable'][0];
-                                $functions  = explode('.', $match['function'][0]);
-                                $parameters = explode(',', $match['parameters'][0]);
+                                $functions  = $match['function'][0] ? explode('.', $match['function'][0]) : array();
+                                $parameters = $match['parameters'][0] ? explode(',', $match['parameters'][0]) : array();
                                 $nbCalls    = count($functions);
 
                                 if ($request->attributes->has($varName)) {

--- a/BreadcrumbTrail/Trail.php
+++ b/BreadcrumbTrail/Trail.php
@@ -89,25 +89,47 @@ class Trail implements \IteratorAggregate, \Countable
             $request = $this->container->get('request', ContainerInterface::NULL_ON_INVALID_REFERENCE);
 
             if ($request !== null) {
-                preg_match_all('#\{(?P<variable>\w+).?(?P<function>\w*):?(?P<parameters>(\w|,| )*)\}#', $breadcrumb_or_title, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+                preg_match_all('#\{(?P<variable>\w+).?(?P<function>([\w\.])*):?(?P<parameters>(\w|,| )*)\}#', $breadcrumb_or_title, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+
                 foreach ($matches as $match) {
-                    $varName = $match['variable'][0];
-                    $functionName = $match['function'][0];
+                    $varName    = $match['variable'][0];
+                    $functions  = explode('.', $match['function'][0]);
                     $parameters = explode(',', $match['parameters'][0]);
+                    $nbCalls    = count($functions);
 
                     if($request->attributes->has($varName)) {
                         $object = $request->attributes->get($varName);
 
-                        if(empty($functionName)) {
+                        if(empty($functions)) {
                             $objectValue = (string) $object;
                         }
-                        elseif(is_callable(array($object, $fullFunctionName = 'get'.$functionName))
-                            || is_callable(array($object, $fullFunctionName = 'has'.$functionName))
-                            || is_callable(array($object, $fullFunctionName = 'is'.$functionName))) {
-                            $objectValue = call_user_func_array(array($object, $fullFunctionName),$parameters);
-                        }
                         else {
-                            throw new \RuntimeException(sprintf('Function "%s" not found.', $functionName));
+                            foreach ($functions AS $f => $function) {
+
+                                # While this is not the last function, call the chain
+                                if ($f < $nbCalls - 1) {
+                                    if(is_callable(array($object, $fullFunctionName = 'get'.$function))
+                                        || is_callable(array($object, $fullFunctionName = 'has'.$function))
+                                        || is_callable(array($object, $fullFunctionName = 'is'.$function))) {
+                                        $object = call_user_func(array($object, $fullFunctionName));
+                                    }
+                                    else {
+                                        throw new \RuntimeException(sprintf('"%s" is not callable.', join('.', array_merge([$varName], $functions))));
+                                    }
+                                }
+
+                                # End of the chain: call the method
+                                else {
+                                    if(is_callable(array($object, $fullFunctionName = 'get'.$function))
+                                        || is_callable(array($object, $fullFunctionName = 'has'.$function))
+                                        || is_callable(array($object, $fullFunctionName = 'is'.$function))) {
+                                        $objectValue = call_user_func_array(array($object, $fullFunctionName),$parameters);
+                                    }
+                                    else {
+                                        throw new \RuntimeException(sprintf('"%s" is not callable.', join('.', array_merge([$varName], $functions))));
+                                    }
+                                }
+                            }
                         }
 
                         $breadcrumb_or_title = str_replace($match[0][0], $objectValue, $breadcrumb_or_title);
@@ -119,28 +141,51 @@ class Trail implements \IteratorAggregate, \Countable
                         $routeParameters[$value] = $request->get($value);
                         unset($routeParameters[$key]);
                     } else {
-                        if (preg_match_all('#\{(?P<variable>\w+).?(?P<function>\w*):?(?P<parameters>(\w|,| )*)\}#', $value, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER)) {
+                        if (preg_match_all('#\{(?P<variable>\w+).?(?P<function>([\w\.])*):?(?P<parameters>(\w|,| )*)\}#', $value, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER)) {
 
                             foreach ($matches AS $match) {
 
-                                $varName      = $match['variable'][0];
-                                $functionName = $match['function'][0];
-                                $parameters   = explode(',', $match['parameters'][0]);
+                                $varName    = $match['variable'][0];
+                                $functions  = explode('.', $match['function'][0]);
+                                $parameters = explode(',', $match['parameters'][0]);
+                                $nbCalls    = count($functions);
 
                                 if ($request->attributes->has($varName)) {
                                     $object = $request->attributes->get($varName);
 
-                                    if (empty($functionName)) {
+                                    if (empty($functions)) {
                                         $objectValue = (string) $object;
                                     }
-                                    elseif (is_callable(array($object, $fullFunctionName = 'get' . $functionName))
-                                        || is_callable(array($object, $fullFunctionName  = 'has' . $functionName))
-                                        || is_callable(array($object, $fullFunctionName  = 'is' . $functionName))
-                                    ) {
-                                        $objectValue = call_user_func_array(array($object, $fullFunctionName), $parameters);
-                                    }
                                     else {
-                                        throw new \RuntimeException(sprintf('Function "%s" not found.', $functionName));
+                                        foreach ($functions AS $f => $function) {
+
+                                            # While this is not the last function, call the chain
+                                            if ($f < $nbCalls - 1) {
+                                                if (is_callable(array($object, $fullFunctionName = 'get' . $function))
+                                                    || is_callable(array($object, $fullFunctionName  = 'has' . $function))
+                                                    || is_callable(array($object, $fullFunctionName  = 'is' . $function))
+                                                ) {
+                                                    $object = call_user_func(array($object, $fullFunctionName));
+                                                }
+                                                else {
+                                                    throw new \RuntimeException(sprintf('"%s" is not callable.', join('.', array_merge([$varName], $functions))));
+                                                }
+                                            }
+
+                                            # End of the chain: call the method
+                                            else {
+
+                                                if (is_callable(array($object, $fullFunctionName = 'get' . $function))
+                                                    || is_callable(array($object, $fullFunctionName  = 'has' . $function))
+                                                    || is_callable(array($object, $fullFunctionName  = 'is' . $function))
+                                                ) {
+                                                    $objectValue = call_user_func_array(array($object, $fullFunctionName), $parameters);
+                                                }
+                                                else {
+                                                    throw new \RuntimeException(sprintf('"%s" is not callable.', join('.', array_merge([$varName], $functions))));
+                                                }
+                                            }
+                                        }
                                     }
 
                                     $routeParameter        = str_replace($match[0][0], $objectValue, $value);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-#2015-11-09
- - Allow complex expressions in route parameters
+#2015-11-10
+ - Allow complex expressions in breadcrumb names and route parameters
 
 #2014-04-18
  - Rewrite documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#2015-11-09
+ - Allow complex expressions in route parameters
+
 #2014-04-18
  - Rewrite documentation
 

--- a/Resources/doc/annotation_configuration.md
+++ b/Resources/doc/annotation_configuration.md
@@ -176,28 +176,30 @@ The two following expressions are equivalents :
  */
 ```
 
-#### Routes with complex parameters
+### Complex parameters
 
-Assume that you have the following controller :
+Assume your controllers are designed like a REST API and you have a ManyToOne relationship on Book -> Author :
 
 ```php
 /**
- * @Route("/object/{object}", name="my_route", requirements={"object" = "\d+"})
- * @Breadcrumb("Level 1", route={"name"="my_route", "parameters"={"object"="{object.id}"}})
+ * @Route("/books/{book}", name="book", requirements={"book" = "\d+"}) // example: /book/53
+ * @Breadcrumb("{book.author.name}", route={"name"="author", "parameters"={"author"="{book.author.id}"}}) // example: /author/15
+ * @Breadcrumb("{book.title}", route={"name"="book", "parameters"={"book"="{book.id}"}})
  * 
  * @param Request $request
- * @param Object $object
+ * @param Book $book
  * @return array
  */
-public function indexAction(Request $request, Object $object) {
+public function indexAction(Request $request, Book $book) {
     return [
-        'id'   => $object->getId(),
-        'name' => $object->getName(),
+        'id'     => $book->getId(),
+        'title'  => $book->getTitle(),
+        'author' => $book->getAuthor()->getName(),
     ];
 }
 ```
 
-As you can see, you can generate a route by querying {object.id} (that will translate to $object->getId()) into the route parameters.
+
 
 ### Position
 

--- a/Resources/doc/annotation_configuration.md
+++ b/Resources/doc/annotation_configuration.md
@@ -176,6 +176,29 @@ The two following expressions are equivalents :
  */
 ```
 
+#### Routes with complex parameters
+
+Assume that you have the following controller :
+
+```php
+/**
+ * @Route("/object/{object}", name="my_route", requirements={"object" = "\d+"})
+ * @Breadcrumb("Level 1", route={"name"="my_route", "parameters"={"object"="{object.id}"}})
+ * 
+ * @param Request $request
+ * @param Object $object
+ * @return array
+ */
+public function indexAction(Request $request, Object $object) {
+    return [
+        'id'   => $object->getId(),
+        'name' => $object->getName(),
+    ];
+}
+```
+
+As you can see, you can generate a route by querying {object.id} (that will translate to $object->getId()) into the route parameters.
+
 ### Position
 
 ```php


### PR DESCRIPTION
Hi,

I had a need to use objects in route parameters. This was possible only in the breadcrumb's title, i.e 
```php
/**
 * @Route("/book/{id}")
 * @Breadcrumb("Books")
 * @Breadcrumb("{book.title}")
 */
public function myAction(Book $book)
{
    /* Awesome code here */
}
```

Now it's possible to use the same syntax in route parameters (assumed it's "ParamConverted"):
```php
/**
 * @Route("/book/{book}", name="book_view", requirements={"book" = "\d+"})
 * @Breadcrumb("Books")
 * @Breadcrumb("{book.title}", routeName="book_view", routeParameters={"id":"{book.id}"})
 */
public function myAction(Book $book)
{
    /* Awesome code here */
}
```
If $book has a __toString() implementation that lead to _$book->getTitle()_, _routeParameters={"id":"{book}"})_ formerly did not retrieve the id but the title, and _{book.id}_ was not evaluated. This is now solved.
