### PR TITLE
Fix deprecation in Trail

### DIFF
--- a/BreadcrumbTrail/Trail.php
+++ b/BreadcrumbTrail/Trail.php
@@ -203,7 +203,8 @@ class Trail implements \IteratorAggregate, \Countable
 
             $url = null;
             if ( !is_null($routeName) ) {
-                $url = $this->router->generate($routeName, $routeParameters, $routeAbsolute);
+                $referenceType = $routeAbsolute ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::RELATIVE_PATH;
+                $url = $this->router->generate($routeName, $routeParameters, $referenceType);
             }
 
             $breadcrumb = new Breadcrumb($breadcrumb_or_title, $url, $attributes);


### PR DESCRIPTION
Fix the following deprecation : 
``` 
The hardcoded value you are using for the $referenceType argument of the Symfony\Component\Routing\Generator\UrlGenerator::generate method is deprecated since version 2.8 and will not be supported anymore in 3.0. Use the constants defined in the UrlGeneratorInterface instead. 
````
