### PR TITLE
Fix `UrlGeneratorInterface` deprecation

### DIFF
--- a/BreadcrumbTrail/Trail.php
+++ b/BreadcrumbTrail/Trail.php
@@ -73,7 +73,7 @@ class Trail implements \IteratorAggregate, \Countable
      * @throws \InvalidArgumentException
      * @return self
      */
-    public function add($breadcrumb_or_title, $routeName = null, $routeParameters = array(), $routeAbsolute = false, $position = 0, $attributes = array())
+    public function add($breadcrumb_or_title, $routeName = null, $routeParameters = array(), $routeAbsolute = UrlGeneratorInterface::ABSOLUTE_PATH, $position = 0, $attributes = array())
     {
         if ($breadcrumb_or_title === null) {
             return $this->reset();


### PR DESCRIPTION
Right now a `boolean` is used. Accompanying deprecation message:

> The hardcoded value you are using for the $referenceType argument of the Symfony\Component\Routing\Generator\UrlGenerator::generate method is deprecated since version 2.8 and will not be supported anymore in 3.0. Use the constants defined in the UrlGeneratorInterface instead.