### PR TITLE
Make compatible with the new syntax without configure the templating

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -26,7 +26,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('template')
-                    ->defaultValue('APYBreadcrumbTrailBundle::breadcrumbtrail.html.twig')
+                    ->defaultValue('@APYBreadcrumbTrail/breadcrumbtrail.html.twig')
                 ->end()
              ->end()
         ;

--- a/Twig/BreadcrumbTrailExtension.php
+++ b/Twig/BreadcrumbTrailExtension.php
@@ -54,7 +54,7 @@ class BreadcrumbTrailExtension extends \Twig_Extension
     public function renderBreadcrumbTrail($template = null)
     {
         $breadcrumbs = $this->container->get("apy_breadcrumb_trail");
-        return $this->container->get("templating")->render(
+        return $this->container->get("twig")->render(
                 $template == null ? $breadcrumbs->getTemplate() : $template,
                 array( 'breadcrumbs' => $breadcrumbs )
         );


### PR DESCRIPTION
The bundle isn't compatible with Symfony 3.4+ or 4+.

1st method, the configuration (without apply @Richard87's patch, #35, but also need to remove the hardcoding dependency):

a) We need to configure the old templating in the config.yml, now the bundle can use the templating service

```yaml
# app/config/config.yml
framework:
    templating:
        engines: ['twig']
```

b) Override the template in config.yml

```yaml
apy_breadcrumb_trail:
    template: '@APYBreadcrumbTrail/breadcrumbtrail.html.twig'
```

2nd method, the bundle patch to v2 with this pull request.