### PR TITLE
Fix autowiring issue

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -18,6 +18,8 @@
             </call>
         </service>
 
+        <service id="%apy_breadcrumb_trail.class%" alias="apy_breadcrumb_trail" public="true"/>
+
         <service id="apy_breadcrumb_trail.twig.extension" class="%apy_breadcrumb_trail.twig.extension.class%">
             <argument type="service" id="apy_breadcrumb_trail" />
             <argument type="service" id="templating" />

--- a/Resources/doc/php_configuration.md
+++ b/Resources/doc/php_configuration.md
@@ -3,7 +3,7 @@
 Add breadcumbs to the trail with PHP in your controller.
 
 
-## Basic example
+## Basic example (without autowiring)
 
 ```php
 /**
@@ -18,6 +18,31 @@ class MyController extends Controller
     public function myAction()
     {
         $this->get("apy_breadcrumb_trail")->add('Level 4');
+    }
+}
+```
+
+Will render the following breadcrumb trail :
+
+> Level 1 > Level 2 > Level 3 > Level 4
+
+## Basic example (with autowiring)
+
+```php
+use APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail;
+
+/**
+ * @Breadcrumb("Level 1")
+ * @Breadcrumb("Level 2")
+ */
+class MyController extends Controller
+{
+    /**
+     * @Breadcrumb("Level 3")
+     */
+    public function myAction(Trail $trail)
+    {
+        $trail->add('Level 4');
     }
 }
 ```


### PR DESCRIPTION
This pull request configures the `APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail` class to be autowired.

At the moment, this class cannot be autowired.

```php
<?php

namespace App\Controller;

use APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail;
use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
use Symfony\Component\HttpFoundation\Response;

class CoreController extends AbstractController
{
    public function index(Trail $trail): Response
    {
        $trail->add('Title');
        return new Response();
    }
}
```
The code above raises a `Runtime Exception`:

```
Cannot autowire argument $trail of "App\Controller\CoreController::index()": it references class "APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail" but no such service exists. You should maybe alias this class to the existing "apy_breadcrumb_trail" service.
```