### PR TITLE
Allow Symfony 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+composer.lock

--- a/EventListener/BreadcrumbListener.php
+++ b/EventListener/BreadcrumbListener.php
@@ -12,9 +12,9 @@
 namespace APY\BreadcrumbTrailBundle\EventListener;
 
 use Doctrine\Common\Annotations\Reader;
-use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail;
 use APY\BreadcrumbTrailBundle\Annotation\Breadcrumb;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class BreadcrumbListener
@@ -43,9 +43,9 @@ class BreadcrumbListener
     }
 
     /**
-     * @param FilterControllerEvent $event A FilterControllerEvent instance
+     * @param \Symfony\Component\HttpKernel\Event\FilterControllerEvent|\Symfony\Component\HttpKernel\Event\ControllerEvent  $event
      */
-    public function onKernelController(FilterControllerEvent $event)
+    public function onKernelController(KernelEvent $event)
     {
         if (!is_array($controller = $event->getController())) {
             return;

--- a/Twig/BreadcrumbTrailExtension.php
+++ b/Twig/BreadcrumbTrailExtension.php
@@ -14,6 +14,7 @@ namespace APY\BreadcrumbTrailBundle\Twig;
 use APY\BreadcrumbTrailBundle\BreadcrumbTrail\Trail;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Provides an extension for Twig to output breadcrumbs
@@ -43,7 +44,7 @@ class BreadcrumbTrailExtension extends AbstractExtension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction("apy_breadcrumb_trail_render", array($this, "renderBreadcrumbTrail"), array("is_safe" => array("html"))),
+            new TwigFunction("apy_breadcrumb_trail_render", array($this, "renderBreadcrumbTrail"), array("is_safe" => array("html"))),
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-intl": "*"
     },
     "autoload": {
-        "psr-0": { "APY\\BreadcrumbTrailBundle": "" }
+        "psr-4": { "APY\\BreadcrumbTrailBundle\\": "" }
     },
     "target-dir": "APY/BreadcrumbTrailBundle"
 }

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "^2.3|^3.0|^4.0",
-        "twig/twig": "^1.41|^2.0"
+        "symfony/framework-bundle": "^2.3|^3.0|^4.0|^5.0",
+        "twig/twig": "^1.41|^2.0|^3.0"
     },
     "suggest": {
         "ext-intl": "*"


### PR DESCRIPTION
These were the only changes needed to get this Bundle working on my Symfony 5.0 project.

As this Bundle has no tests and CI, it is safer to wait for other user's feedback.